### PR TITLE
feature: inject a banner into print view of timesheet to kick off scr…

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,17 +2,28 @@
   "name": "Auto Timesheet Extension",
   "description": "Captures a screenshot of your timesheet and sends via email",
   "version": "1.0",
+  "host_permissions": [
+    "<all_urls>"
+  ],
   "manifest_version": 3,
   "permissions": [
     "identity",
     "tabs",
-    "activeTab"
+    "activeTab",
+    "scripting"
   ],
   "action": {
     "default_popup": "popup/popup.html",
     "default_title": "Capture Timesheet"
   },
   "background": {
-    "service_worker": "service_worker.js"
-  }
+    "service_worker": "service_worker.js",
+    "type": "module"
+  },
+  "content_scripts": [
+    {
+      "matches": ["https://*.hays.com.au/HaysOnline/TSShow.aspx*"],
+      "js": ["scripts/content_script.js"]
+    }
+  ]
 }

--- a/scripts/auth.js
+++ b/scripts/auth.js
@@ -6,6 +6,8 @@ const GMAIL_SEND_SCOPE = 'https://www.googleapis.com/auth/gmail.send';
 
 async function authenticateAndGetToken(interactive = true) {
   return new Promise((resolve, reject) => {
+    console.log(' └─ Beginning authentication and token retrieval');
+
     // 1) Chrome auto-generates a redirect URI for your extension.
     // Typically: https://<EXTENSION_ID>.chromiumapp.org/...
     const redirectUri = chrome.identity.getRedirectURL();

--- a/scripts/content_script.js
+++ b/scripts/content_script.js
@@ -1,0 +1,47 @@
+// Create a banner
+const banner = document.createElement('div');
+banner.textContent = "Click here to screenshot & email! Configure your options in the extension popup itself.";
+
+// Set banner styling
+banner.style.position = 'absolute';
+banner.style.top = '0';
+banner.style.left = '0';
+banner.style.width = '100%';
+banner.style.backgroundColor = '#ffeb3b';
+banner.style.padding = '10px';
+banner.style.fontWeight = 'bold';
+banner.style.cursor = 'pointer';
+banner.style.zIndex = '99999';
+banner.style.textAlign = 'center';
+banner.style.fontSize = '0.8rem';
+banner.style.background = 'linear-gradient(to right, rgb(249, 168, 212), rgb(216, 180, 254), rgb(129, 140, 248))';
+banner.style.color = '#ffffff';
+
+// Insert banner as the first element in the body and push all other page contents down
+document.body.insertBefore(banner, document.body.firstChild);
+
+requestAnimationFrame(() => {
+  const bannerHeight = banner.offsetHeight; // measure the rendered height
+  document.body.style.marginTop = bannerHeight + 'px';
+});
+
+// Insert onClick listener to trigger screenshot + email workflow
+banner.addEventListener('click', () => {
+
+  console.log('Banner clicked, sending message for screenshot/email...');
+  
+  // Send a message requesting the screenshot/email workflow to the 
+  // service worker and await response
+  chrome.runtime.sendMessage({ action: 'capture_and_email' }, (response) => {
+
+    if (response && response.error) {
+      console.error('Error from background:', response.error);
+      alert('Error: ' + response.error);
+    } else if (response && response.success) {
+      console.log('Screenshot/email completed successfully!');
+      alert('Screenshot emailed successfully!');
+    }
+    
+  });
+
+});

--- a/scripts/gmail.js
+++ b/scripts/gmail.js
@@ -1,4 +1,7 @@
 function buildMimeMessage(to, subject, messageText, base64Image) {
+
+  console.log(' └─ Building Mime message contents');
+
   const boundary = 'boundary123';
   const mime =
 `To: ${to}
@@ -29,6 +32,7 @@ ${base64Image}
 }
 
 async function sendGmailMessage(accessToken, rawMime) {
+  console.log(' └─ Sending Gmail');
   const res = await fetch('https://www.googleapis.com/gmail/v1/users/me/messages/send', {
     method: 'POST',
     headers: {

--- a/scripts/screenshot.js
+++ b/scripts/screenshot.js
@@ -1,13 +1,16 @@
 // Example helper for capturing screenshot by sending a message to background
-function captureScreenshot() {
-  return new Promise((resolve, reject) => {
-    chrome.runtime.sendMessage({ action: 'capture_screenshot' }, (response) => {
-      if (!response || response.error) {
-        return reject(new Error(response?.error || 'No response'));
-      }
-      resolve(response.screenshot);
-    });
-  });
+async function captureScreenshot() {
+  console.log(" └─ Beginning screenshot capture");
+  try {
+    // Query the active tab
+    const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+    if (!tab) throw new Error('No active tab');
+    // Capture as JPEG (or PNG)
+    const screenshot = await chrome.tabs.captureVisibleTab(tab.windowId, { format: 'jpeg' });
+    return screenshot;
+  } catch (err) {
+    throw err;
+  }
 }
 
 export { captureScreenshot };


### PR DESCRIPTION
# Contents

This PR introduces a content script to inject a clickable banner into the print view of a Hays timesheet. Clicking this banner initiates the screenshot + emailing process already built into this extension. This likely temporarily breaks the extension page popup but that will be rectified when that gets turned into an options page.

# Proof of work

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/f3410079-5908-4d03-8aa5-5bad752c2d0d" />
